### PR TITLE
Display recommended sets as text and handle bodyweight exercises

### DIFF
--- a/progressTracker.js
+++ b/progressTracker.js
@@ -1,5 +1,6 @@
 // progressTracker.js
 import dataManager from './dataManager.js';
+import { exerciseLibrary } from './models/exerciseLibrary.js';
 
 class ProgressTracker {
     constructor() {
@@ -113,13 +114,23 @@ class ProgressTracker {
             const progress = await this.dataManager.getProgress(userId);
             const profile = await this.dataManager.getUserProfile(userId);
             const exerciseData = progress[exercise];
+            const exerciseInfo = exerciseLibrary.find(e => e.name === exercise);
+            const equipment = exerciseInfo?.equipment || '';
+            const isBodyweight = ['Bodyweight', 'TRX', 'Dip Bar'].includes(equipment);
 
             if (exerciseData?.history?.length > 0) {
                 const last = exerciseData.history[exerciseData.history.length - 1];
                 const set = last.sets && last.sets[0];
-                const weight = (set?.weight || 0) + 5;
                 const reps = set?.reps || 8;
+                if (isBodyweight) {
+                    return { weight: 0, reps };
+                }
+                const weight = (set?.weight || 0) + 5;
                 return { weight, reps };
+            }
+
+            if (isBodyweight) {
+                return { weight: 0, reps: 8 };
             }
 
             return { weight: profile.age, reps: 8 };

--- a/workoutTracker.js
+++ b/workoutTracker.js
@@ -37,12 +37,30 @@ async function renderWorkoutUI(exercises) {
     const exercise = exercises[index];
     const rec = await progressTracker.getRecommendedSet(currentUser, exercise.name);
     const div = document.createElement('div');
-    div.innerHTML = `
-      <h4>${exercise.name}</h4>
-      <div class="recommendation">Recommended: ${rec.weight} lbs × ${rec.reps} reps</div>
-      <input type="number" id="weight-${index}" placeholder="Weight" value="${rec.weight}">
-      <input type="number" id="reps-${index}" placeholder="Reps" value="${rec.reps}">
-    `;
+    const isBodyweight = ['Bodyweight', 'TRX', 'Dip Bar'].includes(exercise.equipment);
+
+    if (isBodyweight) {
+      div.innerHTML = `
+        <h4>${exercise.name}</h4>
+        <div>
+          <input type="number" id="reps-${index}" placeholder="Reps">
+          <span class="recommendation">Recommended: ${rec.reps} reps</span>
+        </div>
+      `;
+    } else {
+      div.innerHTML = `
+        <h4>${exercise.name}</h4>
+        <div>
+          <input type="number" id="weight-${index}" placeholder="Weight">
+          <span class="recommendation">Recommended: ${rec.weight} lbs</span>
+        </div>
+        <div>
+          <input type="number" id="reps-${index}" placeholder="Reps">
+          <span class="recommendation">Recommended: ${rec.reps} reps</span>
+        </div>
+      `;
+    }
+
     container.appendChild(div);
   }
 }
@@ -51,7 +69,8 @@ document.getElementById('completeWorkoutBtn')?.addEventListener('click', async (
   const performance = {};
   document.querySelectorAll('#workoutContainer > div').forEach((div, index) => {
     const name = div.querySelector('h4').textContent;
-    const weight = parseFloat(div.querySelector(`#weight-${index}`).value) || 0;
+    const weightInput = div.querySelector(`#weight-${index}`);
+    const weight = weightInput ? parseFloat(weightInput.value) || 0 : 0;
     const reps = parseInt(div.querySelector(`#reps-${index}`).value) || 0;
     performance[name] = [{ weight, reps }];
   });


### PR DESCRIPTION
## Summary
- Use exercise library to detect bodyweight movements and omit weight recommendations
- Show recommended weight and rep values as text beside inputs instead of prefilled fields
- Skip weight inputs when logging bodyweight exercise performance

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68967ffe403c8320a8f0b2a90c7ff148