### PR TITLE
Remove weight fields from bodyweight exercises

### DIFF
--- a/analytics/growthTracker.js
+++ b/analytics/growthTracker.js
@@ -11,10 +11,18 @@ export async function calculateGrowth(userId, exerciseName) {
   // Sort logs chronologically
   logs.sort((a, b) => new Date(a.completedAt) - new Date(b.completedAt));
 
+  const usesWeight = logs.some(log => {
+    const sets = log.performance[exerciseName];
+    return sets && sets.some(set => set.weight !== undefined);
+  });
+
   const extractAverage = (log) => {
     const sets = log.performance[exerciseName];
     if (!sets || sets.length === 0) return 0;
-    return sets.reduce((sum, set) => sum + (set.reps * set.weight), 0) / sets.length;
+    if (usesWeight) {
+      return sets.reduce((sum, set) => sum + (set.reps * set.weight), 0) / sets.length;
+    }
+    return sets.reduce((sum, set) => sum + set.reps, 0) / sets.length;
   };
 
   const firstAvg = extractAverage(logs[0]);
@@ -28,6 +36,6 @@ export async function calculateGrowth(userId, exerciseName) {
   return {
     trend,
     change,
-    method: 'Avg Volume (reps x weight)'
+    method: usesWeight ? 'Avg Volume (reps x weight)' : 'Avg Reps'
   };
 }

--- a/dataManager.js
+++ b/dataManager.js
@@ -473,13 +473,26 @@ class DataManager {
         if (!exercise.sets || exercise.sets.length === 0) return;
 
         const currentBest = exercise.sets.reduce((best, set) => {
-            if (set.weight > (best?.weight || 0)) {
+            if (set.weight !== undefined) {
+                if (!best || set.weight > (best.weight || 0)) {
+                    return set;
+                }
+                return best;
+            }
+            if (!best || best.weight !== undefined || set.reps > (best.reps || 0)) {
                 return set;
             }
             return best;
         }, exerciseProgress.personalBest);
 
-        if (currentBest && (!exerciseProgress.personalBest.weight || currentBest.weight > exerciseProgress.personalBest.weight)) {
+        const previousBest = exerciseProgress.personalBest;
+        if (!currentBest) return;
+        const isWeighted = currentBest.weight !== undefined;
+        const shouldUpdate = isWeighted
+            ? currentBest.weight > (previousBest?.weight || 0)
+            : (previousBest?.weight !== undefined || currentBest.reps > (previousBest?.reps || 0));
+
+        if (shouldUpdate) {
             exerciseProgress.personalBest = {
                 ...currentBest,
                 date: new Date().toISOString()

--- a/progressTracker.js
+++ b/progressTracker.js
@@ -116,27 +116,27 @@ class ProgressTracker {
             const exerciseData = progress[exercise];
             const exerciseInfo = exerciseLibrary.find(e => e.name === exercise);
             const equipment = exerciseInfo?.equipment || '';
-            const isBodyweight = ['Bodyweight', 'TRX', 'Dip Bar'].includes(equipment);
+            const isWeighted = ['Dumbbell', 'Kettlebell'].includes(equipment);
 
             if (exerciseData?.history?.length > 0) {
                 const last = exerciseData.history[exerciseData.history.length - 1];
                 const set = last.sets && last.sets[0];
                 const reps = set?.reps || 8;
-                if (isBodyweight) {
-                    return { weight: 0, reps };
+                if (!isWeighted) {
+                    return { reps };
                 }
                 const weight = (set?.weight || 0) + 5;
                 return { weight, reps };
             }
 
-            if (isBodyweight) {
-                return { weight: 0, reps: 8 };
+            if (!isWeighted) {
+                return { reps: 8 };
             }
 
             return { weight: profile.age, reps: 8 };
         } catch (error) {
             console.error('Error getting recommended set:', error);
-            return { weight: 0, reps: 8 };
+            return { reps: 8 };
         }
     }
 
@@ -150,10 +150,13 @@ class ProgressTracker {
         if (!data || data.length === 0) return null;
         const allSets = data.flatMap(entry => entry.sets || []);
         return allSets.reduce((best, current) => {
-            if (!best || (current.weight && current.weight > best.weight)) {
-                return current;
+            if (!best) return current;
+            if (current.weight !== undefined && best.weight !== undefined) {
+                return current.weight > best.weight ? current : best;
             }
-            return best;
+            if (current.weight !== undefined) return current;
+            if (best.weight !== undefined) return best;
+            return current.reps > best.reps ? current : best;
         }, null);
     }
 

--- a/workoutTracker.js
+++ b/workoutTracker.js
@@ -37,11 +37,15 @@ async function renderWorkoutUI(exercises) {
     const exercise = exercises[index];
     const rec = await progressTracker.getRecommendedSet(currentUser, exercise.name);
     const div = document.createElement('div');
-    const isBodyweight = ['Bodyweight', 'TRX', 'Dip Bar'].includes(exercise.equipment);
+    const isWeighted = ['Dumbbell', 'Kettlebell'].includes(exercise.equipment);
 
-    if (isBodyweight) {
+    if (isWeighted) {
       div.innerHTML = `
         <h4>${exercise.name}</h4>
+        <div>
+          <input type="number" id="weight-${index}" placeholder="Weight">
+          <span class="recommendation">Recommended: ${rec.weight} lbs</span>
+        </div>
         <div>
           <input type="number" id="reps-${index}" placeholder="Reps">
           <span class="recommendation">Recommended: ${rec.reps} reps</span>
@@ -50,10 +54,6 @@ async function renderWorkoutUI(exercises) {
     } else {
       div.innerHTML = `
         <h4>${exercise.name}</h4>
-        <div>
-          <input type="number" id="weight-${index}" placeholder="Weight">
-          <span class="recommendation">Recommended: ${rec.weight} lbs</span>
-        </div>
         <div>
           <input type="number" id="reps-${index}" placeholder="Reps">
           <span class="recommendation">Recommended: ${rec.reps} reps</span>
@@ -70,9 +70,13 @@ document.getElementById('completeWorkoutBtn')?.addEventListener('click', async (
   document.querySelectorAll('#workoutContainer > div').forEach((div, index) => {
     const name = div.querySelector('h4').textContent;
     const weightInput = div.querySelector(`#weight-${index}`);
-    const weight = weightInput ? parseFloat(weightInput.value) || 0 : 0;
     const reps = parseInt(div.querySelector(`#reps-${index}`).value) || 0;
-    performance[name] = [{ weight, reps }];
+    if (weightInput) {
+      const weight = parseFloat(weightInput.value) || 0;
+      performance[name] = [{ weight, reps }];
+    } else {
+      performance[name] = [{ reps }];
+    }
   });
 
   await logWorkout({


### PR DESCRIPTION
## Summary
- Show weight inputs only for dumbbell and kettlebell exercises; bodyweight entries log reps only
- Refine progress tracking and personal best logic to handle exercises without weights
- Calculate growth using average reps for bodyweight movements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689681bc8f5483209c088d34d85d3aea