### PR TITLE
Add progress graphs and modernize UI

### DIFF
--- a/progress.html
+++ b/progress.html
@@ -7,6 +7,7 @@ File: progress.html
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Progress Tracker</title>
+  <script defer src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>

--- a/progress.js
+++ b/progress.js
@@ -1,11 +1,19 @@
 // =============================
-// File: progress.js (updated)
+// File: progress.js
 // =============================
-import { fetchLogsByUser } from './models/workoutLogs.js';
+import { fetchLogsByUser, fetchLogsByExercise } from './models/workoutLogs.js';
 import { calculateGrowth } from './analytics/growthTracker.js';
 import dataManager from './dataManager.js';
 
 let currentUser = 'Dad';
+
+function hexToRgba(hex, alpha) {
+  const h = hex.replace('#', '');
+  const r = parseInt(h.substring(0, 2), 16);
+  const g = parseInt(h.substring(2, 4), 16);
+  const b = parseInt(h.substring(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
 
 window.addEventListener('DOMContentLoaded', async () => {
   currentUser = await dataManager.getCurrentUser();
@@ -17,16 +25,62 @@ window.addEventListener('DOMContentLoaded', async () => {
 
   const container = document.getElementById('growthContainer');
   container.innerHTML = '';
+  const styles = getComputedStyle(document.documentElement);
+  const lineColor = styles.getPropertyValue('--primary').trim();
+  const fillColor = hexToRgba(lineColor, 0.2);
 
   for (const exerciseName of allExercises) {
     const growth = await calculateGrowth(currentUser, exerciseName);
+    const logData = await fetchLogsByExercise(currentUser, exerciseName);
+    logData.sort((a, b) => new Date(a.completedAt) - new Date(b.completedAt));
+
+    const usesWeight = logData.some(log => {
+      const sets = log.performance[exerciseName];
+      return sets && sets.some(set => set.weight !== undefined);
+    });
+
+    const labels = logData.map(log => new Date(log.completedAt).toLocaleDateString());
+    const dataPoints = logData.map(log => {
+      const sets = log.performance[exerciseName];
+      if (!sets || sets.length === 0) return 0;
+      if (usesWeight) {
+        return sets.reduce((sum, set) => sum + (set.reps * (set.weight || 0)), 0) / sets.length;
+      }
+      return sets.reduce((sum, set) => sum + set.reps, 0) / sets.length;
+    });
+
     const card = document.createElement('div');
     card.className = 'growth-card';
     card.innerHTML = `
       <h4>${exerciseName}</h4>
-      <p>Trend: ${growth.trend}</p>
-      <p>Change: ${growth.change}% (${growth.method})</p>
+      <canvas aria-label="Progress chart for ${exerciseName}" role="img"></canvas>
+      <p>Trend: ${growth.trend} | Change: ${growth.change}% (${growth.method})</p>
     `;
     container.appendChild(card);
+
+    const ctx = card.querySelector('canvas').getContext('2d');
+    const isMobile = window.matchMedia('(max-width: 600px)').matches;
+    new window.Chart(ctx, {
+      type: 'line',
+      data: {
+        labels,
+        datasets: [{
+          data: dataPoints,
+          borderColor: lineColor,
+          backgroundColor: fillColor,
+          tension: 0.3,
+          fill: true
+        }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: { legend: { display: false } },
+        scales: {
+          y: { beginAtZero: true },
+          x: { ticks: { maxTicksLimit: isMobile ? 4 : 8 } }
+        }
+      }
+    });
   }
 });

--- a/styles.css
+++ b/styles.css
@@ -1,9 +1,108 @@
-padding: 0.4rem;
+/* =============================
+   File: styles.css
+   Mid-century modern theme
+   ============================= */
+
+:root {
+  --bg: #f5f2e8;
+  --primary: #d1495b;
+  --secondary: #00798c;
+  --accent: #edae49;
+  --text: #2e2d2b;
+  --card-bg: #fffdf7;
+}
+
+body {
+  font-family: 'Futura', 'Helvetica', sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  margin: 0;
+}
+
+header {
+  background: var(--secondary);
+  color: var(--bg);
+  text-align: center;
+  padding: 1rem 0;
+  box-shadow: 0 2px 0 rgba(0,0,0,0.1);
+}
+
+h1 {
+  margin: 0;
+  font-weight: 400;
+  letter-spacing: 1px;
+}
+
+.user-select {
+  margin-left: 1rem;
+  padding: 0.3rem 0.6rem;
+  border-radius: 4px;
+  border: 1px solid var(--text);
+  background: var(--bg);
+  color: var(--text);
+}
+
+.dashboard-nav {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5rem;
+  background: var(--primary);
+  padding: 0.5rem;
+}
+
+.dashboard-nav button {
+  background: var(--accent);
+  border: none;
+  color: var(--text);
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  font-size: 1rem;
+  cursor: pointer;
+  box-shadow: 0 2px 0 rgba(0,0,0,0.2);
+  transition: background 0.2s;
+}
+
+.dashboard-nav button:hover {
+  background: var(--secondary);
+  color: var(--bg);
+}
+
+main {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.growth-card {
+  background: var(--card-bg);
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.growth-card canvas {
+  width: 100%;
+  height: 200px;
+  margin-bottom: 0.5rem;
+}
+
+input[type="text"],
+input[type="number"],
+select {
+  padding: 0.4rem;
   margin: 0.3rem 0;
   width: 100%;
   box-sizing: border-box;
   border-radius: 4px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--text);
+  background: var(--card-bg);
+  color: var(--text);
+}
+
+button, select {
+  font-family: inherit;
 }
 
 form {
@@ -13,7 +112,7 @@ form {
 .progress-link {
   display: inline-block;
   margin-top: 1rem;
-  color: #3498db;
+  color: var(--primary);
   text-decoration: none;
 }
 
@@ -40,15 +139,20 @@ form {
   border-radius: 50%;
   display: block;
   margin: 4px auto 0;
-  background: #bbb;
+  background: var(--secondary);
 }
 
-.weekly-schedule .dot.pending { background: #e74c3c; }
-.weekly-schedule .dot.completed { background: #27ae60; }
+.weekly-schedule .dot.pending {
+  background: var(--primary);
+}
+
+.weekly-schedule .dot.completed {
+  background: var(--accent);
+}
 
 .recommendation {
   font-size: 0.9rem;
-  color: #555;
+  color: var(--text);
 }
 
 /* Responsive */
@@ -70,4 +174,9 @@ form {
     width: 100%;
     margin-top: 0.5rem;
   }
+
+  .growth-card canvas {
+    height: 140px;
+  }
 }
+


### PR DESCRIPTION
## Summary
- Display exercise progress with inline charts
- Refresh global styles with a mid-century modern palette
- Tune charts for mobile with responsive sizing and simplified ticks
- Pin Chart.js version and pull chart colors from theme variables
- Clean up lingering merge artifact in progress script header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689684a0aa808320a6b6acde16f013e6